### PR TITLE
Fix full source inclusion

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -86,7 +86,7 @@ macro(configure_file_content content file)
   set(CMAKE_CONFIGURABLE_FILE_CONTENT
     "${content}\n")
   configure_file(
-    ${CMAKE_SOURCE_DIR}/cmake/configurable_file_content.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/configurable_file_content.in
     ${file}
     @ONLY)
 endmacro()


### PR DESCRIPTION
When this project is included as `add_subdirectory(...)`, then 

```
CMake Error: File /Users/bogdan/tools/ed25519-cli/cmake/configurable_file_content.in does not exist.
CMake Error at iroha-ed25519/cmake/functions.cmake:88 (configure_file):
  configure_file Problem configuring file
Call Stack (most recent call first):
  iroha-ed25519/cmake/ed25519_export.cmake:5 (configure_file_content)
  iroha-ed25519/CMakeLists.txt:55 (ed25519_export)
```

arises.

This PR fixes this.