### PR TITLE
Add missing close() calls for files

### DIFF
--- a/lib/randombytes/random/random.c
+++ b/lib/randombytes/random/random.c
@@ -13,6 +13,7 @@ int randombytes(unsigned char *p, int len) {
     while (completed < len) {
       ssize_t result = read(source, p + completed, len - completed);
       if (result < 0) {
+        close(source);
         return ED25519_ERROR;
       }
       completed += result;

--- a/lib/randombytes/urandom/urandom.c
+++ b/lib/randombytes/urandom/urandom.c
@@ -9,9 +9,12 @@ int randombytes(unsigned char *p, int len) {
   } else {
     ssize_t result = read(source, p, len);
     if (result < 0) {
+      close(source);
       return ED25519_ERROR; /* something went wrong */
     }
   }
+
+  close(source);
 
   return ED25519_SUCCESS;
 }


### PR DESCRIPTION
Fix issues with system filedescriptor table being flooded with descriptors during long runs of binaries using the lib.