### PR TITLE
Add x86_64 to linux check.

### DIFF
--- a/cmake/ed25519_merge_libraries.cmake
+++ b/cmake/ed25519_merge_libraries.cmake
@@ -46,7 +46,7 @@ function(ed25519_merge_libraries TARGET LIBTYPE)
 
       else()
         # it is shared library
-        if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+        if ((${CMAKE_SYSTEM_NAME} MATCHES "Linux") AND (${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64"))
           ed25519_target_link_libraries(amd64-64-24k-pic
             "-Wl,--version-script=${CMAKE_SOURCE_DIR}/linker_exportmap"
             )


### PR DESCRIPTION
Signed-off-by: Takeshi Yonezu <tkyonezu@gmail.com>

**Description of the Change**

In ed25519_merge_libraries.cmake, where linux is only check, CPU check is also added.

**Benefits**

This addition will allow us to build correctly on non-linux / x86_64 environments.

**Possible Drawbacks**
None